### PR TITLE
Import and export additions

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -2,11 +2,9 @@
     "node": true,
     "strict": "globals",
     "esversion": 6,
+    "browser": true,
     "globals": {
-        "require": false,
-        "angular": false,
-        "$": false,
-        "document": false
+        "$": false
     },
     "predef": [
         "angular"

--- a/source/css/_custom.scss
+++ b/source/css/_custom.scss
@@ -105,4 +105,13 @@
     background-color: $color-disclaimer-background;
     font-style: italic;
 }
+
+#drop-zone {
+    padding: 10% 0;
+    text-align: center;
+    min-height: 100px;
+    background-color: $color-light-grey;
+    border: 1px solid $color-medium-grey;
+    border-radius: 6px;
+}
 //endregion

--- a/source/css/_material-design.scss
+++ b/source/css/_material-design.scss
@@ -150,14 +150,21 @@ md-toast {
     }
 }
 
-.md-button.md-audit-success-theme {
-    & {
-        color: $color-green !important;
+.md-button {
+    &.md-audit-success-theme {
+        min-width: 50px;
     }
 
-    &.md-raised {
-        background-color: $color-green !important;
-        color: $color-light-grey !important;
+    &.md-audit-info-theme {
+        min-width: 50px;
+    }
+
+    &.md-audit-warning-theme {
+        min-width: 50px;
+    }
+
+    &.md-audit-error-theme {
+        min-width: 50px;
     }
 }
 

--- a/source/css/_stdtags.scss
+++ b/source/css/_stdtags.scss
@@ -80,6 +80,7 @@ textarea {
     transition-duration: 0.3s;
     transition-property: background-color, border;
     transition-timing-function: cubic-bezier(0.55, 0, 0.55, 0.2);
+    border-radius: 6px;
 
     &:focus {
         @include border-radius(4px);

--- a/source/javascript/components/accounts/imex.html
+++ b/source/javascript/components/accounts/imex.html
@@ -2,28 +2,28 @@
     <md-toolbar class="md-primary md-hue-3">
         <div class="md-toolbar-tools">
             <h2>
-                <span>Import Configuration</span>
+                <span>Import Accounts</span>
             </h2>
             <span flex></span>
         </div>
     </md-toolbar>
     <section class="md-whiteframe-2dp md-padding">
         <div>
-            <form name="configImport" ng-submit="vm.importConfig()">
+            <form name="accountImport" ng-submit="vm.importAccounts()">
                 <textarea
-                        id="configData"
-                        name="configData"
+                        id="accountData"
+                        name="accountData"
                         layout-fill
                         style="min-height: 400px; resize: none; padding: 8px 4px;"
                         json
                         ng-model="vm.importData.content"
-                        ng-class="{'error': configImport.configData.$error.json}"
+                        ng-class="{'error': accountImport.accountData.$error.json}"
                         placeholder="Drag and drop file here"></textarea>
                 <br>
                 <div class="help-block">
                     Only .json files under 5MB in size are supported
                 </div>
-                <md-button class="md-primary md-raised md-hue-2" type="submit" ng-disabled="!configImport.$valid">
+                <md-button class="md-primary md-raised md-hue-2" type="submit" ng-disabled="!accountImport.$valid">
                     Import
                 </md-button>
             </form>
@@ -35,19 +35,18 @@
     <md-toolbar class="md-primary md-hue-3">
         <div class="md-toolbar-tools">
             <h2>
-                <span>Export Configuration</span>
+                <span>Export Accounts</span>
             </h2>
             <span flex></span>
         </div>
     </md-toolbar>
     <section class="md-whiteframe-2dp md-padding">
         <download-file
-                url="/api/v1/config/imex"
-                label="Export configuration"
-                tooltip="Download configuration"
-                filename="cloud-inquisitor-config"
+                url="/api/v1/account/imex"
+                label="Export accounts"
+                tooltip="Download accounts"
+                filename="cloud-inquisitor-accounts"
                 formats="['json']"
         ></download-file>
-        <!--<md-button class="md-raised" ng-click="vm.exportConfig();">Export configuration</md-button>-->
     </section>
 </div>

--- a/source/javascript/components/accounts/imex.js
+++ b/source/javascript/components/accounts/imex.js
@@ -1,0 +1,98 @@
+'use strict';
+
+angular
+    .module('cloud-inquisitor.components')
+    .component('accountImportExport', {
+        bindings: {
+            onImport: '<',
+            onExport: '<',
+            params: '<',
+            result: '<'
+        },
+        controller: AccountImportExportController,
+        controllerAs: 'vm',
+        templateUrl: 'accounts/imex.html'
+    })
+;
+
+AccountImportExportController.$inject = ['$scope', 'Utils', '$mdDialog'];
+function AccountImportExportController($scope, Utils, $mdDialog) {
+    const vm = this;
+    vm.importData = {
+        percent: 0,
+        content: null
+    };
+    vm.onDrop = onDrop;
+    vm.onDragOver = onDragOver;
+    vm.importAccounts = importAccounts;
+    vm.$onInit = onInit;
+
+    function onInit() {
+        const drop = $('#accountData')[0];
+        drop.addEventListener('drop', vm.onDrop);
+        drop.addEventListener('dragover', vm.onDragOver);
+    }
+
+    function onLoadEnd(evt) {
+        vm.importData.percent = 100;
+        vm.importData.content = Utils.toPrettyJSON(evt.target.result);
+        $scope.$apply();
+    }
+
+    function onDragOver(evt) {
+        evt.preventDefault();
+    }
+
+    function onDrop(evt) {
+        evt.stopPropagation();
+        evt.preventDefault();
+
+        const files = evt.dataTransfer.files;
+        let reader = new window.FileReader();
+        reader.onloadend = onLoadEnd;
+
+        if (files.length !== 1) {
+            Utils.toast('You can only load a single file at a time', 'error');
+        } else {
+            const f = files[0];
+
+            if (f.type !== 'application/json') {
+                Utils.toast('Invalid file type, only supports .json files', 'error');
+                return;
+            }
+
+            if (f.size > 5 * 1024 * 1024) {
+                Utils.toast('Files must be less than 5MB in size', 'error');
+                return;
+            }
+
+            reader.readAsText(f);
+        }
+    }
+
+    function importAccounts() {
+        const confirm = $mdDialog.confirm()
+            .title('Import account')
+            .textContent(
+                'Are you sure you want to import these accounts. Any existing conflicting accounts will be overridden'
+            )
+            .ariaLabel('Import accounts')
+            .ok('Import')
+            .cancel('Cancel');
+
+        $mdDialog.show(confirm).then(() => {
+            vm.onImport(
+                {
+                    config: vm.importData.content
+                },
+                onImportSuccess,
+                Utils.onLoadFailure
+            );
+        });
+    }
+
+    function onImportSuccess(response) {
+        Utils.toast(response.message, 'success');
+        Utils.goto('account.list');
+    }
+}

--- a/source/javascript/components/accounts/index.js
+++ b/source/javascript/components/accounts/index.js
@@ -3,4 +3,5 @@
 require('./add');
 require('./details');
 require('./edit');
+require('./imex');
 require('./list');

--- a/source/javascript/components/accounts/list.html
+++ b/source/javascript/components/accounts/list.html
@@ -61,6 +61,10 @@
             <md-tooltip md-direction="bottom">Add Account</md-tooltip>
             <md-icon md-font-set="material-icons">add outline</md-icon>
         </md-button>
+        <md-button aria-label="import export" ui-sref="account.imex" class="md-fab md-raised md-primary md-mini">
+            <md-tooltip md-direction="bottom">Import / Export Accounts</md-tooltip>
+            <md-icon md-font-set="material-icons">import_export</md-icon>
+        </md-button>
     </md-fab-actions>
 </md-fab-speed-dial>
 <br />

--- a/source/javascript/components/configuration/imex.html
+++ b/source/javascript/components/configuration/imex.html
@@ -1,0 +1,53 @@
+<div>
+    <md-toolbar class="md-primary md-hue-3">
+        <div class="md-toolbar-tools">
+            <h2>
+                <span>Import Configuration</span>
+            </h2>
+            <span flex></span>
+        </div>
+    </md-toolbar>
+    <section class="md-whiteframe-2dp md-padding">
+        <div>
+            <form name="configImport" ng-submit="vm.importConfig()">
+                <textarea
+                        id="configData"
+                        name="configData"
+                        layout-fill
+                        style="min-height: 400px; resize: none; padding: 8px 4px;"
+                        json
+                        ng-model="vm.importData.content"
+                        ng-class="{'error': configImport.configData.$error.json}"
+                        placeholder="Load or drop file here"></textarea>
+                <br>
+                <div class="help-block">
+                    Only .json files under 5MB in size are supported
+                </div>
+                <md-button class="md-primary md-raised md-hue-2" type="submit" ng-disabled="!configImport.$valid">
+                    Import
+                </md-button>
+            </form>
+        </div>
+    </section>
+</div>
+
+<div>
+    <md-toolbar class="md-primary md-hue-3">
+        <div class="md-toolbar-tools">
+            <h2>
+                <span>Export Configuration</span>
+            </h2>
+            <span flex></span>
+        </div>
+    </md-toolbar>
+    <section class="md-whiteframe-2dp md-padding">
+        <download-file
+                url="/api/v1/config/imex"
+                label="Export configuration"
+                tooltip="Download configuration"
+                filename="cloud-inquisitor-config"
+                formats="['json']"
+        ></download-file>
+        <!--<md-button class="md-raised" ng-click="vm.exportConfig();">Export configuration</md-button>-->
+    </section>
+</div>

--- a/source/javascript/components/configuration/imex.js
+++ b/source/javascript/components/configuration/imex.js
@@ -1,0 +1,102 @@
+'use strict';
+
+angular
+    .module('cloud-inquisitor.components')
+    .component('configImportExport', {
+        bindings: {
+            onImport: '<',
+            onExport: '<',
+            params: '<',
+            result: '<'
+        },
+        controller: ConfigImportExportController,
+        controllerAs: 'vm',
+        templateUrl: 'configuration/imex.html'
+    })
+;
+
+ConfigImportExportController.$inject = ['$scope', 'Utils', '$mdDialog'];
+function ConfigImportExportController($scope, Utils, $mdDialog) {
+    const vm = this;
+    vm.importData = {
+        percent: 0,
+        content: null
+    };
+    vm.onDrop = onDrop;
+    vm.onDragOver = onDragOver;
+    vm.exportConfig = exportConfig;
+    vm.importConfig = importConfig;
+    vm.$onInit = onInit;
+
+    function onInit() {
+        const drop = $('#configData')[0];
+        drop.addEventListener('drop', vm.onDrop);
+        drop.addEventListener('dragover', vm.onDragOver);
+    }
+
+    function onLoadEnd(evt) {
+        vm.importData.percent = 100;
+        vm.importData.content = Utils.toPrettyJSON(evt.target.result);
+        $scope.$apply();
+    }
+
+    function onDragOver(evt) {
+        evt.preventDefault();
+    }
+
+    function onDrop(evt) {
+        evt.stopPropagation();
+        evt.preventDefault();
+
+        const files = evt.dataTransfer.files;
+        let reader = new window.FileReader();
+        reader.onloadend = onLoadEnd;
+
+        if (files.length !== 1) {
+            Utils.toast('You can only load a single file at a time', 'error');
+        } else {
+            const f = files[0];
+
+            if (f.type !== 'application/json') {
+                Utils.toast('Invalid file type, only supports .json files', 'error');
+                return;
+            }
+
+            if (f.size > 5 * 1024 * 1024) {
+                Utils.toast('Files must be less than 5MB in size', 'error');
+                return;
+            }
+
+            reader.readAsText(f);
+        }
+    }
+
+    function exportConfig() {
+        const config = vm.onExport();
+        console.log(config);
+    }
+
+    function importConfig() {
+        const confirm = $mdDialog.confirm()
+            .title('Import configuration')
+            .textContent('Are you sure you want to import this configuration. Any ')
+            .ariaLabel('Import configuration')
+            .ok('Import')
+            .cancel('Cancel');
+
+        $mdDialog.show(confirm).then(() => {
+            vm.onImport(
+                {
+                    config: vm.importData.content
+                },
+                onImportSuccess,
+                Utils.onLoadFailure
+            );
+        });
+    }
+
+    function onImportSuccess(response) {
+        Utils.toast(response.message, 'success');
+        Utils.goto('config.list');
+    }
+}

--- a/source/javascript/components/configuration/index.js
+++ b/source/javascript/components/configuration/index.js
@@ -1,5 +1,6 @@
 'use strict';
 
+require('./imex');
 require('./itemAdd');
 require('./itemEdit');
 require('./list');

--- a/source/javascript/components/configuration/list.html
+++ b/source/javascript/components/configuration/list.html
@@ -87,6 +87,10 @@
             <md-tooltip md-direction="bottom">Add Namespace</md-tooltip>
             <md-icon md-font-set="material-icons">add outline</md-icon>
         </md-button>
+        <md-button aria-label="import export" ui-sref="config.imex" class="md-fab md-raised md-primary md-mini">
+            <md-tooltip md-direction="bottom">Import / Export configuration</md-tooltip>
+            <md-icon md-font-set="material-icons">import_export</md-icon>
+        </md-button>
     </md-fab-actions>
 </md-fab-speed-dial>
 <br />

--- a/source/javascript/components/downloadfile/dialog.html
+++ b/source/javascript/components/downloadfile/dialog.html
@@ -19,8 +19,7 @@
                 <md-input-container class="md-block">
                     <label>Format</label>
                     <md-select ng-model="vm.form.fileFormat">
-                        <md-option value="json">JSON</md-option>
-                        <md-option value="xlsx">Excel (xlsx)</md-option>
+                        <md-option ng-repeat="itm in vm.formats" value="{{itm.type}}">{{itm.name}}</md-option>
                     </md-select>
                 </md-input-container>
 

--- a/source/javascript/components/vpc/list.js
+++ b/source/javascript/components/vpc/list.js
@@ -7,14 +7,14 @@ angular
             params: '<',
             result: '<'
         },
-        controller: vpcListController,
+        controller: VpcListController,
         controllerAs: 'vm',
         templateUrl: 'vpc/list.html'
     })
 ;
 
-vpcListController.$inject = ['MetadataService', 'Utils'];
-function vpcListController(MetadataService, Utils) {
+VpcListController.$inject = ['MetadataService', 'Utils'];
+function VpcListController(MetadataService, Utils) {
     const vm = this;
     vm.vpcs = undefined;
     vm.vpcCount = 0;

--- a/source/javascript/factories/api/account.js
+++ b/source/javascript/factories/api/account.js
@@ -41,6 +41,14 @@ function AccountFactory($resource, API_PATH) {
             delete: {
                 method: 'DELETE'
             },
+            export: {
+                url: API_PATH + 'account/imex',
+                method: 'GET'
+            },
+            import: {
+                url: API_PATH + 'account/imex',
+                method: 'POST'
+            },
             query: {
                 url: API_PATH + 'account'
             },

--- a/source/javascript/factories/api/configimex.js
+++ b/source/javascript/factories/api/configimex.js
@@ -1,0 +1,42 @@
+'use strict';
+
+angular
+    .module('cloud-inquisitor.factories')
+    .factory('ConfigImportExport', ConfigItemFactory)
+;
+
+/**
+ * Config Item
+ * @typedef {Object} ConfigItem A configuration item
+ * @property {string} key The key for the config item
+ * @property {JSON} value JSON encoded value
+ * @property {string} type Type of data stored in the key.
+ * @property {string} description A description of the config item
+ * Can be one of `string`, `int`, `float`, `array`, `json` or `bool`
+ * @property {string} namespacePrefix The namespace the config item resides in
+ */
+
+ConfigItemFactory.$inject = ['$resource', 'API_PATH'];
+/**
+ * Configuration Item API factory object
+ * @param {object} $resource Angular Resource object
+ * @param {string} API_PATH API Version path, from constant
+ * @returns {ConfigItem|ConfigItem[]} Returns a {ConfigItem} object or a list of {ConfigItem} objects
+ * @constructor
+ */
+function ConfigItemFactory($resource, API_PATH) {
+    return $resource(
+        API_PATH + 'config/imex',
+        {},
+        {
+            import: {
+                url: API_PATH + 'config/imex',
+                method: 'POST'
+            },
+            export: {
+                url: API_PATH + 'config/imex',
+                method: 'GET'
+            }
+        }
+    );
+}

--- a/source/javascript/factories/api/index.js
+++ b/source/javascript/factories/api/index.js
@@ -2,6 +2,7 @@
 
 require('./account');
 require('./auditlog');
+require('./configimex');
 require('./configitem');
 require('./confignamespace');
 require('./dashboard');

--- a/source/javascript/routes.js
+++ b/source/javascript/routes.js
@@ -518,6 +518,21 @@ function config($stateProvider, $urlServiceProvider) {
                 }
             }
         })
+        .state('config.imex', {
+            url: '/config/imex',
+            component: 'configImportExport',
+            resolve: {
+                onImport: ConfigImportExport => {
+                    return ConfigImportExport.import;
+                },
+                onExport: ConfigImportExport => {
+                    return ConfigImportExport.export;
+                },
+                params: $transition$ => {
+                    return stateParams($transition$);
+                }
+            }
+        })
     ;
     //endregion
 

--- a/source/javascript/routes.js
+++ b/source/javascript/routes.js
@@ -133,6 +133,21 @@ function config($stateProvider, $urlServiceProvider) {
                 }
             }
         })
+        .state('account.imex', {
+            url: '/accounts/imex',
+            component: 'accountImportExport',
+            resolve: {
+                onImport: Account => {
+                    return Account.import;
+                },
+                onExport: Account => {
+                    return Account.export;
+                },
+                params: $transition$ => {
+                    return stateParams($transition$);
+                }
+            }
+        })
     ;
     //endregion
 


### PR DESCRIPTION
Adding support for import/export of config and account data to make it easier setting up a new instance from backed up data. Allows export and import of all accounts and all configuration data in JSON format.