### PR TITLE
feat(account contacts): Updated format for Account contacts

### DIFF
--- a/source/css/_labels.scss
+++ b/source/css/_labels.scss
@@ -11,6 +11,10 @@
     background-color: $color-medium-grey;
     @include border-radius(4px);
 
+    &.large {
+        font-size: 14px !important;
+    }
+
     &:not(last-child) {
         margin-right: 4px;
     }

--- a/source/html/index.html
+++ b/source/html/index.html
@@ -14,6 +14,17 @@
 
         <link rel="stylesheet" href="css/material.css" />
 
+        <!-- favicons etc -->
+        <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png?v=wAO0Joz2Bl">
+        <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png?v=wAO0Joz2Bl">
+        <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png?v=wAO0Joz2Bl">
+        <link rel="manifest" href="/site.webmanifest?v=wAO0Joz2Bl">
+        <link rel="mask-icon" href="/safari-pinned-tab.svg?v=wAO0Joz2Bl" color="#607d8b">
+        <link rel="shortcut icon" href="/favicon.ico?v=wAO0Joz2Bl">
+        <meta name="msapplication-TileColor" content="#607d8b">
+        <meta name="theme-color" content="#607d8b">
+        <!-- end favicons -->
+
         <style type="text/css">
             [ng\:cloak], [ng-cloak], [data-ng-cloak], [x-ng-cloak] {
                 display: none !important;

--- a/source/javascript/components/accounts/addcontact.html
+++ b/source/javascript/components/accounts/addcontact.html
@@ -1,0 +1,34 @@
+<md-dialog aria-label="Add Contact" class="addContact">
+    <form ng-cloak name="frmAddContact" ng-submit="vm.addContact()">
+        <md-toolbar>
+            <div class="md-toolbar-tools">
+                <h2>Add contact for {{vm.accountName}}</h2>
+                <span flex></span>
+                <md-button class="md-icon-button" ng-click="vm.cancel()">
+                    <md-icon aria-label="Close dialog">close</md-icon>
+                </md-button>
+            </div>
+        </md-toolbar>
+
+        <md-dialog-content>
+            <div class="md-dialog-content" style="max-width: 600px;">
+                <md-input-container class="md-block">
+                    <label>Notification method</label>
+                    <md-select ng-model="vm.form.type">
+                        <md-option ng-repeat="itm in vm.supportedTypes" ng-value="itm.type">{{itm.type}}</md-option>
+                    </md-select>
+                </md-input-container>
+            </div>
+        </md-dialog-content>
+
+        <md-dialog-actions layout="row">
+            <span flex></span>
+            <md-button class="md-warn" type="submit" id="btnAddContact">
+                Add Contact
+            </md-button>
+            <md-button ng-click="vm.cancel()">
+                Close
+            </md-button>
+        </md-dialog-actions>
+    </form>
+</md-dialog>

--- a/source/javascript/components/accounts/details.html
+++ b/source/javascript/components/accounts/details.html
@@ -31,7 +31,7 @@
                     <label for="contacts">Contacts:</label>
                 </td>
                 <td md-cell id="contacts">
-                    <span class="labels blue" ng-repeat="contact in vm.account.contacts">{{contact}}</span>
+                    <span ng-repeat="contact in vm.account.contacts" ng-bind-html="contact | contacttype">&nbsp;</span>
                 </td>
             </tr>
 

--- a/source/javascript/components/accounts/edit.html
+++ b/source/javascript/components/accounts/edit.html
@@ -25,13 +25,9 @@
             </div>
 
             <div layout-gt-md="row">
-                <md-input-container class="md-block" flex>
-                    <label for="contacts">Contacts</label>
-                    <md-chips id="contacts" ng-model="vm.account.contacts" required></md-chips>
-
-                    <div ng-messages="accountEdit.contacts.$error" role="alert">
-                        <div ng-message="required" class="my-message">You must provide one or more contact email addresses or slack channels</div>
-                    </div>
+                <md-input-container class="md-block" flex="50">
+                    <label for="adGroupBase">AD Group Base</label>
+                    <input id="adGroupBase" type="text" ng-model="vm.account.adGroupBase" />
                 </md-input-container>
 
                 <span style="width: 40px"></span>
@@ -43,16 +39,20 @@
             </div>
 
             <div layout-gt-md="row">
-                <md-input-container class="md-block" flex="50">
-                    <label for="adGroupBase">AD Group Base</label>
-                    <input id="adGroupBase" type="text" ng-model="vm.account.adGroupBase" />
+                <md-input-container class="md-block" flex>
+                    <label for="requiredRoles">Required Roles</label>
+                    <md-chips id="requiredRoles" ng-model="vm.account.requiredRoles" placeholder="Enter group" flex></md-chips>
                 </md-input-container>
             </div>
 
-            <md-input-container class="md-block" flex>
-                <label for="requiredRoles">Required Roles</label>
-                <md-chips id="requiredRoles" ng-model="vm.account.requiredRoles" placeholder="Enter group" flex></md-chips>
-            </md-input-container>
+            <div layout-gt-md="row">
+                <md-input-container class="md-block" flex>
+                    <label for="contacts">Contacts</label>
+                    <md-chips id="contacts" ng-model="vm.account.contacts" md-transform-chip="vm.onChipAdd($chip)">
+                        <md-chip-template>{{$chip.value}}</md-chip-template>
+                    </md-chips>
+                </md-input-container>
+            </div>
         </md-content>
     </section>
 

--- a/source/javascript/components/accounts/edit.js
+++ b/source/javascript/components/accounts/edit.js
@@ -14,13 +14,15 @@ angular
     })
 ;
 
-AccountEditController.$inject = ['Utils'];
-function AccountEditController(Utils) {
+AccountEditController.$inject = ['Utils', 'MetadataService', '$mdDialog'];
+function AccountEditController(Utils, MetadataService, $mdDialog) {
     const vm = this;
     // @type {Account}
     vm.account = {requiredRoles: [ ]};
     vm.update = update;
     vm.goto = Utils.goto;
+    vm.showAddContact = showAddContact;
+    vm.onChipAdd = onChipAdd;
     vm.$onInit = onInit;
 
     //region Functions
@@ -41,7 +43,85 @@ function AccountEditController(Utils) {
     }
 
     function update() {
+        const data = JSON.parse(JSON.stringify(vm.account));
+        data.contacts = JSON.stringify(vm.account.contacts);
+
         vm.onAccountUpdate(vm.account, onUpdateSuccess, Utils.onLoadFailure);
     }
+
+    function showAddContact(ev) {
+        $mdDialog.show({
+            controller: AccountContactAddController,
+            controllerAs: 'vm',
+            templateUrl: 'accounts/addcontact.html',
+            targetEvent: ev,
+            clickOutsideToClose: true,
+            parent: angular.element(document.body),
+            locals: {
+                params: {
+                    accountName: vm.account.accountName
+                }
+            }
+        });
+    }
+
+    function onChipAdd(chip) {
+        let dlg = {
+            controller: AccountContactAddController,
+            controllerAs: 'vm',
+            templateUrl: 'accounts/addcontact.html',
+            clickOutsideToClose: true,
+            parent: angular.element(document.body),
+            locals: {
+                params: {
+                    accountName: vm.account.accountName,
+                }
+            }
+        };
+
+        $mdDialog.show(dlg).then(
+            result => {
+                for (let notifier of MetadataService.notifiers) {
+                    if (notifier.type === result) {
+                        if (notifier.validation.exec(chip)) {
+                            vm.account.contacts.push({
+                                type: result,
+                                value: chip
+                            });
+                        } else {
+                            Utils.toast('Invalid formatted contact for ' + result, 'error');
+                        }
+                        return;
+                    }
+                }
+
+                Utils.toast('Invalid contact type', 'error');
+            },
+            res => {}
+        );
+
+        return null;
+    }
     //endregion
+}
+
+AccountContactAddController.$inject = ['$mdDialog', 'MetadataService', 'params'];
+function AccountContactAddController($mdDialog, MetadataService, params) {
+    const vm = this;
+    vm.form = {
+        type: undefined
+    };
+    vm.supportedTypes = MetadataService.notifiers;
+    vm.accountName = params.accountName;
+    vm.cancel = $mdDialog.cancel;
+    vm.addContact = addContact;
+    vm.$onInit = onInit;
+
+    // region Functions
+    function onInit() {}
+
+    function addContact() {
+        $mdDialog.hide(vm.form.type);
+    }
+    // endregion
 }

--- a/source/javascript/components/accounts/list.html
+++ b/source/javascript/components/accounts/list.html
@@ -13,7 +13,7 @@
             <tbody md-body>
             <tr md-row ng-repeat="acct in vm.accounts" id="acct-{{acct.accountId}}">
                 <td md-cell style="width: 200px !important;">{{acct.accountName}}</td>
-                <td md-cell><span class="labels" ng-repeat="contact in acct.contacts" ng-class="{blue: contact.indexOf('@') > -1}">{{contact}}</span></td>
+                <td md-cell><span ng-repeat="contact in acct.contacts" ng-bind-html="contact | contacttype">&nbsp;</span></td>
                 <td md-cell style="text-align: center;" ng-bind-html="vm.accountTypeLabel(acct.accountType)"></td>
                 <td md-cell style="text-align: center;" ng-bind-html="acct.enabled | status">&nbsp;</td>
                 <td md-cell style="width: 40px; text-align: right; padding-right: 35px;">

--- a/source/javascript/factories/utils.js
+++ b/source/javascript/factories/utils.js
@@ -57,7 +57,8 @@ function Utils($injector, $window, Session) {
         gotoLogin: gotoLogin,
         getResourceTypeName: getResourceTypeName,
         resourceTypeToRoute: resourceTypeToRoute,
-        showDetails: showDetails
+        showDetails: showDetails,
+        validateEmail: validateEmail
     };
 
     //region Functions
@@ -411,6 +412,16 @@ function Utils($injector, $window, Session) {
             const typeName = getResourceTypeName(resource.resourceType);
             toast('Details for ' +  typeName + ' objects not yet supported', 'warning');
         }
+    }
+
+    /**
+     * Validate email address is properly formed
+     * @param {string} email Email address to validate
+     * @return {boolean}
+     */
+    function validateEmail(email) {
+        var re = /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
+        return re.test(String(email).toLowerCase());
     }
     //endregion
 }

--- a/source/javascript/filters/contacttype.js
+++ b/source/javascript/filters/contacttype.js
@@ -1,0 +1,23 @@
+'use strict';
+
+angular
+    .module('cloud-inquisitor.filters')
+    .filter('contacttype', loglevel)
+;
+
+loglevel.$inject = ['$sce'];
+function loglevel($sce) {
+    const types = {
+        'email': 'blue',
+        'slack': 'orange',
+    };
+
+    return input => {
+        let cls = 'default';
+        if (types.hasOwnProperty(input.type)) {
+            cls = types[input.type];
+        }
+
+        return $sce.trustAsHtml('<span class="labels ' + cls + '">' + input.value + '</span>');
+    };
+}

--- a/source/javascript/filters/index.js
+++ b/source/javascript/filters/index.js
@@ -5,6 +5,7 @@ angular.module('cloud-inquisitor.filters', [ ]);
 require('./age');
 require('./bool2icon');
 require('./capitalize');
+require('./contacttype');
 require('./loglevel');
 require('./nl2br');
 require('./orderobjectby');

--- a/source/javascript/services/metadata.js
+++ b/source/javascript/services/metadata.js
@@ -13,6 +13,7 @@ function MetadataService($http, $rootScope, Utils, API_PATH) {
     let menuItems = {};
     let currentUser = {};
     let resourceTypes = {};
+    let notifiers = [];
 
     let initialized = false;
     const utils = Utils;
@@ -23,6 +24,7 @@ function MetadataService($http, $rootScope, Utils, API_PATH) {
         menuItems: menuItems,
         currentUser: currentUser,
         resourceTypes: resourceTypes,
+        notifiers: notifiers,
         load: load
     };
 
@@ -53,6 +55,13 @@ function MetadataService($http, $rootScope, Utils, API_PATH) {
 
                     for (let region of response.data.regions) {
                         regions.push(region);
+                    }
+
+                    for (let notifier of response.data.notifiers) {
+                        notifiers.push({
+                            type: notifier.type,
+                            validation: new RegExp(notifier.validation, 'i')
+                        });
                     }
 
                     for (let [k, v] of Object.entries(response.data.menuItems)) {


### PR DESCRIPTION
Add support for the updated format of account contacts.

Previously, contacts were a simple list of values
```javascript
contacts = ['foo@bar.tld', '#slack-channel']
```
but the new format requires some more metadata around the contacts
```javascript
contacts = [
    { type: 'email', value: 'foo@bar.tld' },
    { type: 'slack', value: '#slack-channel' }
]
```