### PR TITLE
feat(templates): Add support for managing templates from admin console

### DIFF
--- a/source/css/_stdtags.scss
+++ b/source/css/_stdtags.scss
@@ -77,15 +77,15 @@ pre, .code-box {
 }
 
 textarea {
+    @include border-radius(4px);
+    border: 1px solid $color-grey !important;
     transition-duration: 0.3s;
     transition-property: background-color, border;
     transition-timing-function: cubic-bezier(0.55, 0, 0.55, 0.2);
-    border-radius: 6px;
+    min-height: 50px !important;
 
     &:focus {
-        @include border-radius(4px);
-        border: 1px solid $color-grey !important;
-        background-color: $color-light-grey;
+        background-color: $color-light-grey !important;
     }
 
     &.error {

--- a/source/javascript/components/index.js
+++ b/source/javascript/components/index.js
@@ -19,6 +19,7 @@ require('./logs');
 require('./requiredtags');
 require('./roles');
 require('./search');
+require('./templates');
 require('./users');
 require('./volumeaudit');
 require('./vpc');

--- a/source/javascript/components/templates/add.html
+++ b/source/javascript/components/templates/add.html
@@ -1,0 +1,22 @@
+<form name="templateAdd" ng-submit="vm.create()">
+    <section class="md-whiteframe-2dp padding">
+        <md-content class="md-padding">
+            <div layout-gt-md="row">
+                <md-input-container class="md-block" flex>
+                    <label>Name</label>
+                    <input name="templateName" type="text" ng-model="vm.template.templateName" required />
+                </md-input-container>
+            </div>
+
+            <div layout-gt-md="row">
+                <md-input-container class="md-block" flex>
+                    <label>Template</label>
+                    <textarea name="template" ng-model="vm.template.template"></textarea>
+                </md-input-container>
+            </div>
+        </md-content>
+    </section>
+
+    <md-button class="md-primary md-raised md-hue-2" type="submit" ng-disabled="!templateAdd.$valid">Create</md-button>
+    <md-button class="md-warn md-raised" onclick="history.back()">Cancel</md-button>
+</form>

--- a/source/javascript/components/templates/add.js
+++ b/source/javascript/components/templates/add.js
@@ -1,0 +1,37 @@
+'use strict';
+
+angular
+    .module('cloud-inquisitor.components')
+    .component('templateAdd', {
+        bindings: {
+            onTemplateCreate: '<'
+        },
+        controller: TemplateAddController,
+        controllerAs: 'vm',
+        templateUrl: 'templates/add.html'
+    })
+;
+
+TemplateAddController.$inject = ['$rootScope', 'Utils'];
+function TemplateAddController($rootScope, Utils) {
+    const vm = this;
+    vm.template = {
+        templateName: undefined,
+        template: undefined
+    };
+    vm.create = create;
+    vm.$onInit = onInit;
+
+    // region Functions
+    function onInit() { }
+
+    function create() {
+        vm.onTemplateCreate(vm.template, onCreateSuccess, Utils.onLoadFailure);
+    }
+
+    function onCreateSuccess() {
+        Utils.toast('Successfully created template', 'success');
+        Utils.goto('template.list');
+    }
+    // endregion
+}

--- a/source/javascript/components/templates/edit.html
+++ b/source/javascript/components/templates/edit.html
@@ -1,0 +1,22 @@
+<form name="templateEdit" ng-submit="vm.update()">
+    <section class="md-whiteframe-2dp padding">
+        <md-content class="md-padding">
+            <div layout-gt-md="row">
+                <md-input-container class="md-block" flex>
+                    <label>Name</label>
+                    <input name="templateName" type="text" ng-model="vm.template.templateName" disabled required />
+                </md-input-container>
+            </div>
+
+            <div layout-gt-md="row">
+                <md-input-container class="md-block" flex>
+                    <label>Template</label>
+                    <textarea name="template" ng-model="vm.template.template"></textarea>
+                </md-input-container>
+            </div>
+        </md-content>
+    </section>
+
+    <md-button class="md-primary md-raised md-hue-2" type="submit" ng-disabled="!templateEdit.$valid">Update</md-button>
+    <md-button class="md-warn md-raised" onclick="history.back()">Cancel</md-button>
+</form>

--- a/source/javascript/components/templates/edit.js
+++ b/source/javascript/components/templates/edit.js
@@ -1,0 +1,45 @@
+'use strict';
+
+angular
+    .module('cloud-inquisitor.components')
+    .component('templateEdit', {
+        bindings: {
+            params: '<',
+            result: '<',
+            onTemplateUpdate: '<'
+        },
+        controller: TemplateEditController,
+        controllerAs: 'vm',
+        templateUrl: 'templates/edit.html'
+    })
+;
+
+TemplateEditController.$inject = ['$rootScope', 'Utils'];
+function TemplateEditController($rootScope, Utils) {
+    const vm = this;
+    vm.template = {
+        templateName: undefined,
+        template: undefined
+    };
+    vm.update = update;
+    vm.$onInit = onInit;
+
+    // region Functions
+    function onInit() {
+        vm.result.$promise.then(onLoadSuccess, Utils.onLoadFailure);
+    }
+
+    function onLoadSuccess(response) {
+        vm.template = response.template;
+    }
+
+    function update() {
+        vm.onTemplateUpdate(vm.template, onUpdateSuccess, Utils.onLoadFailure);
+    }
+
+    function onUpdateSuccess() {
+        Utils.toast('Updated template ' + vm.template.templateName, 'success');
+        Utils.goto('template.list');
+    }
+    // endregion
+}

--- a/source/javascript/components/templates/index.js
+++ b/source/javascript/components/templates/index.js
@@ -1,0 +1,6 @@
+'use strict';
+
+require('spectrum-colorpicker');
+require('./add');
+require('./edit');
+require('./list');

--- a/source/javascript/components/templates/list.html
+++ b/source/javascript/components/templates/list.html
@@ -1,0 +1,62 @@
+<section class="md-whiteframe-2dp md-padding" ng-cloak>
+    <md-table-container>
+        <table md-table class="striped hover">
+            <thead md-head>
+            <tr md-row>
+                <th md-column style="width: 250px;">Name</th>
+                <th md-column>Template</th>
+                <th md-column style="width: 50px;">&nbsp;</th>
+            </tr>
+            </thead>
+            <tbody md-body>
+            <tr md-row ng-repeat="template in vm.templates" id="template-{{template.templateName}}">
+                <td md-cell>{{template.templateName}}</td>
+                <td md-cell>
+                    {{template.template}}
+                </td>
+                <td md-cell>
+                    <md-menu md-position-mode="target-right target">
+                        <md-button aria-label="Open user interactions menu" class="md-icon-button" ng-click="$mdMenu.open()">
+                            <md-icon md-font-set="material-icons">settings</md-icon>
+                        </md-button>
+                        <md-menu-content width="4">
+                            <md-menu-item>
+                                <md-button ng-click="vm.editTemplate(template)">
+                                    <md-icon md-font-set="material-icons">edit</md-icon>
+                                    Edit
+                                </md-button>
+                            </md-menu-item>
+                            <md-menu-divider></md-menu-divider>
+                            <md-menu-item>
+                                <md-button ng-click="vm.deleteTemplate($event, template)">
+                                    <md-icon md-font-set="material-icons">delete</md-icon>
+                                    Delete
+                                </md-button>
+                            </md-menu-item>
+                        </md-menu-content>
+                    </md-menu>
+                </td>
+            </tr>
+            </tbody>
+        </table>
+    </md-table-container>
+</section>
+
+<md-fab-speed-dial md-open="fabopen" md-direction="left" class="md-scale md-fab-bottom-right" style="position: fixed; bottom: 20px">
+    <md-fab-trigger>
+        <md-button aria-label="menu" class="md-fab md-warn">
+            <md-icon md-font-set="material-icons">menu</md-icon>
+        </md-button>
+    </md-fab-trigger>
+    <md-fab-actions>
+        <md-button aria-label="add template" ui-sref="template.add" class="md-fab md-raised md-primary md-mini">
+            <md-tooltip md-direction="bottom">Add Template</md-tooltip>
+            <md-icon md-font-set="material-icons">add</md-icon>
+        </md-button>
+        <md-button aria-label="import-templates" ng-click="vm.importTemplates()" class="md-fab md-raised md-primary md-mini">
+            <md-tooltip md-direction="bottom">Import Templates</md-tooltip>
+            <md-icon md-font-set="material-icons">import_contacts</md-icon>
+        </md-button>
+    </md-fab-actions>
+</md-fab-speed-dial>
+<br />

--- a/source/javascript/components/templates/list.js
+++ b/source/javascript/components/templates/list.js
@@ -1,0 +1,115 @@
+'use strict';
+
+angular
+    .module('cloud-inquisitor.components')
+    .component('templateList', {
+        bindings: {
+            params: '<',
+            result: '<',
+            onTemplateDelete: '<',
+            onTemplateImport: '<'
+        },
+        controller: TemplateListController,
+        controllerAs: 'vm',
+        templateUrl: 'templates/list.html'
+    })
+;
+
+TemplateListController.$inject = ['$mdDialog', '$state', 'Utils'];
+function TemplateListController($mdDialog, $state, Utils) {
+    const vm = this;
+    vm.templates = [ ];
+    vm.templateCount = 0;
+    vm.deleteTemplate = deleteTemplate;
+    vm.importTemplates = importTemplates;
+    vm.editTemplate = editTemplate;
+    vm.updateFilters = updateFilters;
+    vm.resetFilters = resetFilters;
+    vm.updatePath = updatePath;
+    vm.$onInit = onInit;
+
+    // region Functions
+    function onInit() {
+        vm.result.$promise.then(onLoadSuccess, Utils.onLoadFailure);
+    }
+
+    function onLoadSuccess(response) {
+        vm.templates = response.templates;
+        vm.templateCount = response.templateCount;
+    }
+
+    function deleteTemplate(evt, template) {
+        const confirm = $mdDialog.confirm()
+            .title('Delete ' + template.templateName + '?')
+            .textContent('Are you absolutely sure you want to delete this template: ' + template.templateName + '?')
+            .ariaLabel('Confirm template deletion')
+            .ok('Delete')
+            .cancel('Cancel')
+            .targetEvent(evt);
+
+        $mdDialog
+            .show(confirm)
+            .then(() => {
+                vm.onTemplateDelete({templateName: template.templateName}, onDeleteSuccess, onDeleteFailure);
+            })
+        ;
+    }
+
+    function importTemplates(evt) {
+        const confirm = $mdDialog.confirm()
+            .title('Import templates?')
+            .textContent('Are you absolutely sure you want to reimport' +
+                ' all templates. Any local changes will be destroyed')
+            .ariaLabel('Confirm template import')
+            .ok('Import')
+            .cancel('Cancel')
+            .targetEvent(evt);
+
+        $mdDialog
+            .show(confirm)
+            .then(() => {
+                vm.onTemplateImport({}, onImportSuccess, onImportFailure);
+            })
+        ;
+    }
+
+    function editTemplate(template) {
+        Utils.goto('template.edit', {templateName: template.templateName});
+    }
+
+    function onDeleteSuccess(response) {
+        $('#template-' + response.templateName).remove();
+        Utils.toast('Template was removed', 'success');
+    }
+
+    function onDeleteFailure(response) {
+        Utils.toast('Failed to remove template: ' + response.message);
+    }
+
+    function onImportSuccess(response) {
+        Utils.toast(response.message, 'success');
+        $state.reload();
+    }
+
+    function onImportFailure(response) {
+        Utils.toast('Failed to import templates: ' + response.message);
+    }
+
+    function updateFilters() {
+        vm.params.page = 1;
+        vm.updatePath();
+    }
+
+    function resetFilters() {
+        vm.params = {
+            page: 1,
+            count: 25
+        };
+        vm.updatePath();
+    }
+
+    function updatePath() {
+        Utils.goto('template.list', vm.params);
+    }
+    // endregion
+}

--- a/source/javascript/factories/api/index.js
+++ b/source/javascript/factories/api/index.js
@@ -19,6 +19,7 @@ require('./logout');
 require('./requiredtag');
 require('./role');
 require('./search');
+require('./template');
 require('./user');
 require('./volumeaudit');
 require('./vpc');

--- a/source/javascript/factories/api/template.js
+++ b/source/javascript/factories/api/template.js
@@ -1,0 +1,50 @@
+'use strict';
+
+angular
+    .module('cloud-inquisitor.factories')
+    .factory('Template', TemplateFactory)
+;
+
+/**
+ * Template
+ * @typedef {Object} Template Template object
+ * @property {string} templateName Template name
+ * @property {string} template Body of the template
+ * @property {boolean} isModified True if the user has edited the default template
+ */
+
+TemplateFactory.$inject = ['$resource', 'API_PATH'];
+/**
+ * Template API factory object
+ * @param {object} $resource Angular Resource object
+ * @param {string} API_PATH API Version path, from constant
+ * @returns {Template|Template[]} Returns a {Template} object or a list of {Template} objects
+ * @constructor
+ */
+function TemplateFactory($resource, API_PATH) {
+    return $resource(
+        API_PATH + 'template/:templateName',
+        {
+            templateName: '@templateName'
+        },
+        {
+            query: {
+                url: API_PATH + 'templates'
+            },
+            create: {
+                url: API_PATH + 'templates',
+                method: 'POST'
+            },
+            import: {
+                url: API_PATH + 'templates',
+                method: 'PUT'
+            },
+            update: {
+                method: 'PUT'
+            },
+            delete: {
+                method: 'DELETE'
+            }
+        }
+    );
+}

--- a/source/javascript/routes.js
+++ b/source/javascript/routes.js
@@ -705,6 +705,58 @@ function config($stateProvider, $urlServiceProvider) {
     ;
     //endregion
 
+    //region Templates
+    $stateProvider
+        .state('template', {
+            abstract: true,
+            parent: 'main',
+            template: '<ui-view/>'
+        })
+        .state('template.list', {
+            url: '/templates/list',
+            component: 'templateList',
+            resolve: {
+                onTemplateDelete: Template => {
+                    return Template.delete;
+                },
+                onTemplateImport: Template => {
+                    return Template.import;
+                },
+                params: ($transition$) => {
+                    return stateParams($transition$);
+                },
+                result: (Template, $transition$) => {
+                    return Template.query(stateParams($transition$));
+                }
+            }
+        })
+        .state('template.add', {
+            url: '/template/add',
+            component: 'templateAdd',
+            resolve: {
+                onTemplateCreate: Template => {
+                    return Template.create;
+                },
+            }
+        })
+        .state('template.edit', {
+            url: '/template/edit/{templateName:string}',
+            component: 'templateEdit',
+            resolve: {
+                onTemplateUpdate: Template => {
+                    return Template.update;
+                },
+                params: ($transition$) => {
+                    return stateParams($transition$);
+                },
+                result: (Template, $transition$) => {
+                    return Template.get(stateParams($transition$));
+                }
+            }
+        })
+    ;
+    //endregion
+
     //region EBS Volumes
     $stateProvider
         .state('ebs', {


### PR DESCRIPTION
Instead of relying on templates on disk on the backend server, templates
have been moved into the database. Here we're adding support for
creating, editing and removing templates, so users are able to customize
notification messages.

There is also an option for allow users to re-import templates from disk
to override any local changes that may have been made by the user.

*NOTE*: Please only approve, do not merge this PR