### PR TITLE
Adjusting S3 Bucket List for new website enabled status

### DIFF
--- a/source/javascript/components/s3/list.js
+++ b/source/javascript/components/s3/list.js
@@ -64,7 +64,7 @@ function S3ListController(MetadataService, Utils) {
                 values: {
                     'Enabled': 'Enabled',
                     'Disabled': 'Disabled',
-                    'Unavailable': 'Unavailable'
+                    'cinq cant poll': 'cinq cant poll'
                 },
                 selected: vm.params.websiteEnabled
             }

--- a/source/javascript/components/s3/list.js
+++ b/source/javascript/components/s3/list.js
@@ -64,7 +64,7 @@ function S3ListController(MetadataService, Utils) {
                 values: {
                     'Enabled': 'Enabled',
                     'Disabled': 'Disabled',
-                    'cinq cant poll': 'cinq cant poll'
+                    'cinq cannot poll': 'cinq cannot poll'
                 },
                 selected: vm.params.websiteEnabled
             }


### PR DESCRIPTION
Chaging the unavailable status to 'cinq cant poll' for better clarity to the user.